### PR TITLE
Add local operator record persistence, returning-operator UI, and archive interaction tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
   <meta name="theme-color" content="#050709" />
   <link rel="icon" type="image/png" href="Cradlepoint%20Flavicon.png" />
   <link rel="preload" href="assets/background.jpg" as="image" />
-  <link rel="stylesheet" href="styles.css?v=20260605-toggle1" />
+  <link rel="stylesheet" href="styles.css?v=20260606-state1" />
 </head>
 <body>
   <div class="noise" aria-hidden="true"></div>
@@ -39,9 +39,9 @@
       </div>
 
       <nav class="actions" aria-label="Archive routes">
-        <a class="button primary" href="https://wiki.veildaemon.app/" target="_blank" rel="noopener noreferrer">Read The Archive</a>
+        <a class="button primary" id="archive-route" href="https://wiki.veildaemon.app/" target="_blank" rel="noopener noreferrer">Read The Archive</a>
         <button class="button" type="button" id="start-intake" aria-controls="intake-node" aria-expanded="false">Begin Operator Intake</button>
-        <a class="button" href="https://the-cradlepoint-archives.itch.io/needlepoint" target="_blank" rel="noopener noreferrer">Play The Case File</a>
+        <a class="button" id="case-file-route" href="https://the-cradlepoint-archives.itch.io/needlepoint" target="_blank" rel="noopener noreferrer">Play The Case File</a>
       </nav>
 
       <section class="intake" id="intake-node" aria-label="Operator Intake Node" tabindex="-1" hidden>
@@ -58,13 +58,73 @@
             <p class="intake-step" id="intake-step">INTAKE STATUS: WAITING</p>
             <p class="ai-line" id="ai-line"><span class="prompt">&gt;</span> Press Start Intake to open the question channel.</p>
           </div>
+          <section class="returning-operator" id="returning-operator" aria-label="Returning operator record" hidden>
+            <div class="record-header">
+              <div>
+                <p class="kicker">RETURNING OPERATOR DETECTED</p>
+                <h3>LOCAL RECORD FOUND</h3>
+              </div>
+              <p class="record-badge">NO EXTERNAL ACCOUNT DETECTED</p>
+            </div>
+            <div class="record-grid compact-record-grid">
+              <div><span>DESIGNATION</span><strong id="returning-designation">PENDING</strong></div>
+              <div><span>PRIMARY FREQUENCY</span><strong id="returning-frequency">PENDING</strong></div>
+              <div><span>ATTENTION STATUS</span><strong id="returning-attention">PENDING</strong></div>
+              <div><span>ACCESS LEVEL</span><strong id="returning-access">PENDING</strong></div>
+              <div><span>FILES REVIEWED</span><strong id="returning-files">0</strong></div>
+              <div><span>INCIDENT REFERENCES</span><strong id="returning-incidents">0</strong></div>
+              <div><span>LAST ACTIVITY</span><strong id="returning-last-activity">PENDING</strong></div>
+            </div>
+            <p class="local-note">This browser remembers your intake state. Welcome back. Purge only removes the local browser record.</p>
+            <div class="returning-actions">
+              <button class="button primary" type="button" id="resume-record">Resume Record</button>
+              <button class="button" type="button" id="reclassify-record">Reclassify</button>
+              <button class="button ghost" type="button" id="returning-purge-record">Purge Local Record</button>
+            </div>
+          </section>
           <div class="answer-panel" id="answer-panel" aria-label="Answer choices"></div>
           <div class="intake-result" id="intake-result"></div>
+          <section class="operator-record" id="operator-record" aria-label="Operator record" hidden>
+            <div class="record-header">
+              <div>
+                <p class="kicker">OPERATOR RECORD // LOCAL NODE MEMORY</p>
+                <h3 id="record-designation">DESIGNATION PENDING</h3>
+              </div>
+              <p class="record-badge" id="record-access">ACCESS: UNASSIGNED</p>
+            </div>
+            <div class="record-grid" id="record-grid"></div>
+            <details class="record-details" open>
+              <summary>Drift / observed traits</summary>
+              <div class="record-log" id="record-drift-list"></div>
+            </details>
+            <details class="record-details">
+              <summary>Local state</summary>
+              <div class="record-grid compact-record-grid" id="record-meta"></div>
+            </details>
+            <details class="record-details" open>
+              <summary>Archive flags</summary>
+              <div class="record-log" id="record-flags-list"></div>
+            </details>
+            <details class="record-details">
+              <summary>Incident exposure</summary>
+              <div class="record-log" id="record-exposure-list"></div>
+            </details>
+            <details class="record-details">
+              <summary>Related records</summary>
+              <div class="record-log" id="record-related-list"></div>
+            </details>
+            <details class="record-details">
+              <summary>Classification history</summary>
+              <div class="record-log" id="record-history-list" aria-label="Classification history"></div>
+            </details>
+          </section>
         </div>
 
         <div class="intake-actions">
           <button class="button" type="button" id="reset-intake">Restart Intake</button>
+          <button class="button ghost" type="button" id="purge-record">Purge Local Record</button>
         </div>
+        <p class="local-note">Purge only removes the local browser record. No external account detected.</p>
       </section>
 
       <section class="feed" aria-label="Primary Feed latest transmission">
@@ -103,6 +163,6 @@
       </footer>
     </section>
   </main>
-  <script src="script.js?v=20260605-toggle1"></script>
+  <script src="script.js?v=20260606-state1"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,49 +1,131 @@
+const operatorRecordVersion = 1;
+const recordStorageKey = "veildaemon.operatorRecord.v2";
+const legacyRecordStorageKey = "veildaemon.operatorRecord.v1";
+const archiveUrl = "https://wiki.veildaemon.app/";
+const passDiscordUrl = "https://discord.gg/Bn6attnYN6";
+const triageDiscordUrl = "https://discord.gg/KRbckpfTQk";
+
 const profiles = {
   Dream: {
     title: "DREAM BLEED",
-    route: "Needlepoint / Reflection-Adjacent Case Files",
-    summary: "Symbol, reflection, memory, and route certainty are behaving as active terrain."
+    description: "symbolism, memory geometry, impossible perception",
+    designationSeeds: ["MIRRORWAKE", "DREAM-ECHO", "SYMBOL-INDEX", "NODEWALKER"],
+    observedTraits: ["Pattern seeking", "Symbol retention", "Recursive thought", "Dream residue tolerance"],
+    knownIncident: "Viridian House",
+    recommendedTraining: "Needlepoint First Contact Case File",
+    archiveRoute: archiveUrl,
+    relatedRecords: ["Audience Before", "Mara Venn", "Apartment 13F"]
   },
   Hunger: {
     title: "HUNGER PRESSURE",
-    route: "Sanguine / Desire-Vector Records",
-    summary: "Appetite, need, warmth, pursuit, or escalation may be routing the event."
+    description: "desire, escalation, appetite, pursuit",
+    designationSeeds: ["WANT-SHAPE", "PULSE-HUNGRY", "REDLINE", "HEAT-SIGNAL"],
+    observedTraits: ["Desire tracking", "Escalation sensitivity", "Appetite-pressure response", "High pursuit fixation"],
+    knownIncident: "Hunger Leech / Heat-Lost cross-reference",
+    recommendedTraining: "Stabilization before exposure",
+    archiveRoute: archiveUrl,
+    relatedRecords: ["Heat-Lost", "Empty Kitchen", "Sanguine Threshold"]
   },
   Silence: {
     title: "SILENCE GAP",
-    route: "Redacted Records / Missing-Data Events",
-    summary: "Absence is carrying pressure. Missing names, sounds, records, or context are not neutral."
+    description: "suppression, omission, erasure, concealment",
+    designationSeeds: ["NULL-SIGNAL", "RECORD-GAP", "REDACTION", "QUIET-FILE"],
+    observedTraits: ["Omission detection", "Signal suppression", "Privacy guarding", "Memory gap tolerance"],
+    knownIncident: "Silence Gap / Record Eater cross-reference",
+    recommendedTraining: "Archive handling with witness confirmation",
+    archiveRoute: archiveUrl,
+    relatedRecords: ["Entity File 404", "Missing Name Index", "Record Eater"]
   },
   Stillness: {
     title: "STILLNESS LOOP",
-    route: "Time Drift / Suspended-Choice Reports",
-    summary: "Delay, repetition, restraint, or frozen decision pressure may be stabilizing the anomaly."
+    description: "restraint, control, frozen momentum, precision",
+    designationSeeds: ["HOLDFAST", "PAUSE-LOCK", "STATIC-ANCHOR", "STILL-LOOP"],
+    observedTraits: ["Crisis restraint", "Precision under pressure", "Delay tolerance", "Anchor behavior"],
+    knownIncident: "Stillness Loop / Route Wraith cross-reference",
+    recommendedTraining: "Pressure round containment protocol",
+    archiveRoute: archiveUrl,
+    relatedRecords: ["Delayed Motion Event", "Route Wraith", "Pressure Round"]
   },
   Empyrean: {
     title: "EMPYREAN SIGNAL",
-    route: "Transmission / Witness-Line Records",
-    summary: "Connection, awe, audience, signal, or emotional synchronization may be amplifying contact."
+    description: "emotional synchronization, connection, relational gravity",
+    designationSeeds: ["SIGNAL-CHOIR", "THREAD-LINK", "WITNESS-TREE", "EMPATH-NODE"],
+    observedTraits: ["Emotional synchronization", "Boundary sensitivity", "Group resonance detection", "Witness-pressure response"],
+    knownIncident: "Attention Bloom / Alarm Angel cross-reference",
+    recommendedTraining: "Consent and separation protocol",
+    archiveRoute: archiveUrl,
+    relatedRecords: ["Audience Before", "Alarm Angel", "Witness Line"]
   },
   Becoming: {
     title: "BECOMING EVENT",
-    route: "Identity Drift / Mirror Claim Reports",
-    summary: "Role pressure, self-rewrite, adaptation, or identity mismatch may be shaping the event."
+    description: "identity drift, adaptation, transformation",
+    designationSeeds: ["MASK-SHIFT", "IDENTITY-DRIFT", "BODY-EDIT", "ROLE-FAULT"],
+    observedTraits: ["Adaptive identity response", "Mask recognition", "Social role instability", "Transformation pressure tolerance"],
+    knownIncident: "Becoming Mask / Mirror Claim cross-reference",
+    recommendedTraining: "Identity anchoring protocol",
+    archiveRoute: archiveUrl,
+    relatedRecords: ["Mirror Claim", "Apartment 13F", "Body Edit Log"]
   }
-};
-
-const actionCosts = {
-  ignored: "Residual pressure likely remained local. Monitor for recurrence.",
-  recorded: "Recording may have created a witness channel. Do not replay alone.",
-  told: "Secondary witness created. Compare memories before assuming agreement.",
-  followed: "Route contamination possible. Mark exits before returning.",
-  lied: "Concealment increased pressure. Correct the lie before the room does."
 };
 
 const stateCopy = {
   BRUSHED: "BRUSHED // indirect contact only",
   NOTED: "NOTED // pattern registered",
   MARKED: "MARKED // observer relevance confirmed",
-  CLAIMED: "CLAIMED // disengage and seek live Operators"
+  CLAIMED: "CLAIMED // live triage recommended"
+};
+
+const attentionCopy = {
+  BRUSHED: "BRUSHED",
+  NOTED: "NOTED",
+  MARKED: "MARKED",
+  CLAIMED: "DO NOT SUSTAIN EYE CONTACT"
+};
+
+const actionDrift = {
+  ignored: "Stillness",
+  recorded: "Empyrean",
+  told: "Empyrean",
+  followed: "Hunger",
+  lied: "Silence"
+};
+
+const archiveInteractionProfiles = {
+  archive: {
+    file: "Archive Index",
+    flag: "REVIEWED: Archive Index",
+    incident: "Archive Index",
+    related: ["Audience Before", "Mara Venn", "Apartment 13F"],
+    event: "ARCHIVE ROUTE REVIEWED"
+  },
+  caseFile: {
+    file: "Needlepoint Intake",
+    flag: "REVIEWED: Needlepoint Intake",
+    incident: "Needlepoint Intake",
+    related: ["Viridian House", "Reflection Drift", "Delayed Motion Event"],
+    event: "CASE FILE REVIEWED"
+  },
+  transmission: {
+    file: "Primary Feed Transmission",
+    flag: "WITNESSED: Primary Feed Transmission",
+    incident: "Reflection Drift",
+    related: ["Audience Before", "Entity File 404", "Alarm Angel"],
+    event: "TRANSMISSION PLAYBACK OPENED"
+  },
+  operatorChannel: {
+    file: "Operator Channel Offer",
+    flag: "OBSERVED: The Redacted onboarding signal",
+    incident: "Operator Channel Offer",
+    related: ["The Redacted Intake", "Handler Signal Shade"],
+    event: "OPERATOR CHANNEL OPENED"
+  },
+  triageChannel: {
+    file: "Triage Channel Offer",
+    flag: "OBSERVED: Triage signal",
+    incident: "Triage Channel Offer",
+    related: ["Stabilization Queue", "Attention Bloom"],
+    event: "TRIAGE CHANNEL OPENED"
+  }
 };
 
 const intakeQuestions = [
@@ -88,10 +170,12 @@ const intakeQuestions = [
 const intakeState = {
   currentQuestion: 0,
   answers: {},
-  isTyping: false
+  isTyping: false,
+  record: null,
+  returningDecisionMade: false
 };
 
-const shadeIntro = "Hello. My name is Shade. This intake routes new observers into the VeilCorp Archives. It is not a personality test. It is not about one video. You noticed reality behaving incorrectly. Otherwise you would not be here. Continue? Denial is not a supported answer.";
+const shadeIntro = "Hello. My name is Shade. This intake routes new observers into The Redacted. It is not a personality test. It is not about one video. You noticed reality behaving incorrectly. Otherwise you would not be here. Continue? Denial is not a supported answer.";
 let typingTimer = null;
 
 function clearTypingTimer() {
@@ -99,6 +183,475 @@ function clearTypingTimer() {
     clearTimeout(typingTimer);
     typingTimer = null;
   }
+}
+
+function nowStamp() {
+  return new Date().toISOString();
+}
+
+function daysSince(value) {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return "TIMEBASE UNCERTAIN";
+  }
+
+  const days = Math.max(0, Math.floor((Date.now() - date.getTime()) / 86400000));
+
+  if (days === 0) {
+    return "TODAY";
+  }
+
+  if (days === 1) {
+    return "1 DAY AGO";
+  }
+
+  return `${days} DAYS AGO`;
+}
+
+function addUnique(list, value) {
+  if (!value) {
+    return;
+  }
+
+  if (!list.includes(value)) {
+    list.push(value);
+  }
+}
+
+function addManyUnique(list, values) {
+  values.forEach((value) => addUnique(list, value));
+}
+
+function getFrequencyDriftValue(record, frequency) {
+  const drift = (record.frequencyDrift || []).find((entry) => entry.frequency === frequency);
+  return drift ? drift.value : 0;
+}
+
+function setFrequencyDrift(record, frequency, value) {
+  const existing = (record.frequencyDrift || []).find((entry) => entry.frequency === frequency);
+
+  if (existing) {
+    existing.value = value;
+    return;
+  }
+
+  record.frequencyDrift.push({ frequency, value });
+}
+
+function incrementFrequencyDrift(record, frequency, amount) {
+  setFrequencyDrift(record, frequency, getFrequencyDriftValue(record, frequency) + amount);
+}
+
+function appendHistory(record, event) {
+  if (!record) {
+    return;
+  }
+
+  record.classificationHistory = Array.isArray(record.classificationHistory) ? record.classificationHistory : [];
+  record.classificationHistory.unshift({
+    time: nowStamp(),
+    event
+  });
+  record.classificationHistory = record.classificationHistory.slice(0, 12);
+  record.updatedAt = nowStamp();
+}
+
+function normalizeFrequencyDrift(drift, primaryFrequency) {
+  const driftMap = new Map();
+
+  if (Array.isArray(drift)) {
+    drift.forEach((entry) => {
+      if (entry && profiles[entry.frequency]) {
+        driftMap.set(entry.frequency, Number(entry.value) || 0);
+      }
+    });
+  } else if (drift && typeof drift === "object") {
+    Object.entries(drift).forEach(([frequency, value]) => {
+      if (profiles[frequency]) {
+        driftMap.set(frequency, Number(value) || 0);
+      }
+    });
+  }
+
+  if (primaryFrequency && profiles[primaryFrequency] && !driftMap.has(primaryFrequency)) {
+    driftMap.set(primaryFrequency, 2);
+  }
+
+  return Array.from(driftMap, ([frequency, value]) => ({ frequency, value })).filter((entry) => entry.value > 0);
+}
+
+function normalizeHistory(history) {
+  if (!Array.isArray(history)) {
+    return [];
+  }
+
+  return history.map((entry) => {
+    if (typeof entry === "string") {
+      return { time: nowStamp(), event: entry };
+    }
+
+    return {
+      time: entry.time || entry.updatedAt || nowStamp(),
+      event: entry.event || `PRIMARY FREQUENCY ASSIGNED: ${entry.frequency || "UNKNOWN"}`
+    };
+  }).slice(0, 12);
+}
+
+function normalizeOperatorRecord(record) {
+  if (!record || typeof record !== "object") {
+    return null;
+  }
+
+  const primaryFrequency = profiles[record.primaryFrequency] ? record.primaryFrequency : "Dream";
+  const profile = profiles[primaryFrequency];
+  const createdAt = record.createdAt || nowStamp();
+  const updatedAt = record.updatedAt || createdAt;
+  const discordRoute = record.discordRoute || (record.attentionStatus === "DO NOT SUSTAIN EYE CONTACT" ? triageDiscordUrl : passDiscordUrl);
+
+  return {
+    operatorRecordVersion,
+    designation: record.designation || generateDesignation(primaryFrequency),
+    primaryFrequency,
+    stabilityState: record.stabilityState || record.stability || "NOMINAL",
+    attentionStatus: record.attentionStatus || record.attention || "LOW",
+    accessLevel: record.accessLevel || record.access || "PROVISIONAL",
+    assignmentGroup: record.assignmentGroup || "THE REDACTED",
+    handlerSignal: record.handlerSignal || "SHADE",
+    archiveAuthority: record.archiveAuthority || "VEILCORP",
+    intakeNode: record.intakeNode || "VEILDAEMON",
+    observedTraits: Array.isArray(record.observedTraits) ? record.observedTraits : (record.traits || profile.observedTraits),
+    frequencyDrift: normalizeFrequencyDrift(record.frequencyDrift || record.drift, primaryFrequency),
+    knownIncidents: Array.isArray(record.knownIncidents) ? record.knownIncidents : (record.incidents || [profile.knownIncident]),
+    incidentExposure: Array.isArray(record.incidentExposure) ? record.incidentExposure : (record.knownIncidents || record.incidents || [profile.knownIncident]),
+    archiveFlags: Array.isArray(record.archiveFlags) && record.archiveFlags.length > 0 ? record.archiveFlags : ["OBSERVED: Operator Intake", `CLASSIFIED: ${primaryFrequency}`],
+    relatedRecords: Array.isArray(record.relatedRecords) ? record.relatedRecords : (profile.relatedRecords || []),
+    recommendedTraining: record.recommendedTraining || record.training || profile.recommendedTraining,
+    archiveRoute: record.archiveRoute || profile.archiveRoute,
+    discordRoute,
+    classificationHistory: normalizeHistory(record.classificationHistory || record.history),
+    createdAt,
+    updatedAt,
+    visits: Number(record.visits) || 0,
+    filesReviewed: Number(record.filesReviewed) || 0,
+    lastSeen: record.lastSeen || updatedAt,
+    lastActivity: record.lastActivity || record.lastSeen || updatedAt
+  };
+}
+
+function readOperatorRecord() {
+  try {
+    const storedRecord = window.localStorage.getItem(recordStorageKey) || window.localStorage.getItem(legacyRecordStorageKey);
+    return storedRecord ? normalizeOperatorRecord(JSON.parse(storedRecord)) : null;
+  } catch (error) {
+    return null;
+  }
+}
+
+function writeOperatorRecord(record) {
+  try {
+    window.localStorage.setItem(recordStorageKey, JSON.stringify(record));
+  } catch (error) {
+    // Local state is helpful, not load-bearing.
+  }
+}
+
+function removeOperatorRecord() {
+  try {
+    window.localStorage.removeItem(recordStorageKey);
+    window.localStorage.removeItem(legacyRecordStorageKey);
+  } catch (error) {
+    // Local state is helpful, not load-bearing.
+  }
+}
+
+function generateDesignation(frequency) {
+  const seeds = profiles[frequency].designationSeeds;
+  const seed = seeds[Math.floor(Math.random() * seeds.length)];
+  const digits = window.crypto && window.crypto.getRandomValues
+    ? window.crypto.getRandomValues(new Uint16Array(1))[0] % 1000
+    : Math.floor(Math.random() * 1000);
+
+  return `${seed}-${String(digits).padStart(3, "0")}`;
+}
+
+function determineStabilityState(result) {
+  if (result.risk === "CLAIMED") {
+    return "TRIAGE RECOMMENDED";
+  }
+
+  if (result.risk === "MARKED" && (result.action === "followed" || result.action === "lied")) {
+    return "RECURSIVE";
+  }
+
+  if (result.risk === "MARKED") {
+    return "UNSTABLE";
+  }
+
+  if (result.risk === "NOTED" || result.action === "followed" || result.action === "lied") {
+    return "STRAINED";
+  }
+
+  if (result.action === "ignored") {
+    return "STABLE";
+  }
+
+  return "NOMINAL";
+}
+
+function determineAccessLevel(result) {
+  if (result.risk === "CLAIMED") {
+    return "REDACTED";
+  }
+
+  if (result.risk === "MARKED") {
+    return "CROSS-REFERENCE PENDING";
+  }
+
+  if (result.risk === "NOTED") {
+    return "ARCHIVE LIMITED";
+  }
+
+  return "INTAKE ACCEPTED";
+}
+
+function buildIntakeResult() {
+  const noticed = intakeState.answers.noticed;
+  const action = intakeState.answers.action;
+  const noticedBack = intakeState.answers.noticedBack;
+  const frequency = noticed.value;
+  const risk = noticedBack.value;
+  const profile = profiles[frequency];
+
+  return {
+    frequency,
+    action: action.value,
+    actionLabel: action.label,
+    risk,
+    claimed: risk === "CLAIMED",
+    warning: noticed.warning,
+    profile,
+    attentionStatus: attentionCopy[risk],
+    stabilityState: determineStabilityState({ frequency, action: action.value, risk }),
+    accessLevel: determineAccessLevel({ frequency, action: action.value, risk }),
+    discordRoute: risk === "CLAIMED" ? triageDiscordUrl : passDiscordUrl
+  };
+}
+
+function createOperatorRecord(result) {
+  const timestamp = nowStamp();
+  const record = {
+    operatorRecordVersion,
+    designation: generateDesignation(result.frequency),
+    primaryFrequency: result.frequency,
+    stabilityState: result.stabilityState,
+    attentionStatus: result.attentionStatus,
+    accessLevel: result.accessLevel,
+    assignmentGroup: "THE REDACTED",
+    handlerSignal: "SHADE",
+    archiveAuthority: "VEILCORP",
+    intakeNode: "VEILDAEMON",
+    observedTraits: result.profile.observedTraits.slice(),
+    frequencyDrift: [{ frequency: result.frequency, value: 2 }],
+    knownIncidents: [result.profile.knownIncident],
+    incidentExposure: [result.profile.knownIncident],
+    archiveFlags: ["OBSERVED: Operator Intake", `CLASSIFIED: ${result.frequency}`],
+    relatedRecords: result.profile.relatedRecords.slice(),
+    recommendedTraining: result.profile.recommendedTraining,
+    archiveRoute: result.profile.archiveRoute,
+    discordRoute: result.discordRoute,
+    classificationHistory: [],
+    createdAt: timestamp,
+    updatedAt: timestamp,
+    visits: 1,
+    filesReviewed: 0,
+    lastSeen: timestamp,
+    lastActivity: timestamp
+  };
+
+  appendHistory(record, "LOCAL RECORD INITIALIZED");
+  appendHistory(record, "INTAKE COMPLETED");
+  appendHistory(record, `PRIMARY FREQUENCY ASSIGNED: ${result.frequency.toUpperCase()}`);
+  appendHistory(record, `ATTENTION STATUS UPDATED: ${result.attentionStatus}`);
+  appendHistory(record, "ARCHIVE ROUTE OFFERED");
+  appendHistory(record, result.claimed ? "TRIAGE ROUTE OFFERED" : "OPERATOR CHANNEL OFFERED");
+  return record;
+}
+
+function updateOperatorRecord(record, result) {
+  const nextRecord = normalizeOperatorRecord(record) || createOperatorRecord(result);
+  const wasCreated = nextRecord.classificationHistory.length === 0;
+
+  if (wasCreated) {
+    appendHistory(nextRecord, "LOCAL RECORD INITIALIZED");
+  } else {
+    appendHistory(nextRecord, "RECLASSIFICATION RECEIVED");
+  }
+
+  nextRecord.primaryFrequency = result.frequency;
+  nextRecord.stabilityState = result.stabilityState;
+  nextRecord.attentionStatus = result.attentionStatus;
+  nextRecord.accessLevel = result.accessLevel;
+  nextRecord.assignmentGroup = "THE REDACTED";
+  nextRecord.handlerSignal = "SHADE";
+  nextRecord.archiveAuthority = "VEILCORP";
+  nextRecord.intakeNode = "VEILDAEMON";
+  nextRecord.observedTraits = result.profile.observedTraits.slice();
+  nextRecord.recommendedTraining = result.profile.recommendedTraining;
+  nextRecord.archiveRoute = result.profile.archiveRoute;
+  nextRecord.discordRoute = result.discordRoute;
+  nextRecord.lastSeen = nowStamp();
+
+  addUnique(nextRecord.knownIncidents, result.profile.knownIncident);
+  addUnique(nextRecord.incidentExposure, result.profile.knownIncident);
+  addUnique(nextRecord.archiveFlags, `CLASSIFIED: ${result.frequency}`);
+  addManyUnique(nextRecord.relatedRecords, result.profile.relatedRecords);
+  nextRecord.lastActivity = nowStamp();
+
+  if (getFrequencyDriftValue(nextRecord, result.frequency) === 0) {
+    setFrequencyDrift(nextRecord, result.frequency, 1);
+  } else {
+    incrementFrequencyDrift(nextRecord, result.frequency, wasCreated ? 2 : 1);
+  }
+
+  const secondaryFrequency = actionDrift[result.action];
+  if (secondaryFrequency && secondaryFrequency !== result.frequency) {
+    incrementFrequencyDrift(nextRecord, secondaryFrequency, 1);
+  }
+
+  if (result.risk === "MARKED" && result.frequency !== "Becoming") {
+    incrementFrequencyDrift(nextRecord, "Becoming", 1);
+  }
+
+  appendHistory(nextRecord, "INTAKE COMPLETED");
+  appendHistory(nextRecord, `PRIMARY FREQUENCY ASSIGNED: ${result.frequency.toUpperCase()}`);
+  appendHistory(nextRecord, `ATTENTION STATUS UPDATED: ${result.attentionStatus}`);
+  appendHistory(nextRecord, "ARCHIVE CROSS-REFERENCE PENDING");
+  appendHistory(nextRecord, result.claimed ? "TRIAGE ROUTE OFFERED" : "OPERATOR CHANNEL OFFERED");
+  nextRecord.frequencyDrift = nextRecord.frequencyDrift.filter((entry) => entry.value > 0);
+  nextRecord.updatedAt = nowStamp();
+  return nextRecord;
+}
+
+function formatDate(value) {
+  const date = new Date(value);
+
+  if (Number.isNaN(date.getTime())) {
+    return "TIMEBASE UNCERTAIN";
+  }
+
+  return date.toLocaleString("en-US", {
+    month: "short",
+    day: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit"
+  }).toUpperCase();
+}
+
+function formatDrift(record) {
+  return (record.frequencyDrift || [])
+    .filter((entry) => entry.value > 0)
+    .map((entry) => `${entry.frequency} ${entry.value}`);
+}
+
+function renderOperatorRecord(record) {
+  const recordPanel = document.getElementById("operator-record");
+  const recordGrid = document.getElementById("record-grid");
+  const recordMeta = document.getElementById("record-meta");
+  const driftList = document.getElementById("record-drift-list");
+  const flagsList = document.getElementById("record-flags-list");
+  const exposureList = document.getElementById("record-exposure-list");
+  const relatedList = document.getElementById("record-related-list");
+  const historyList = document.getElementById("record-history-list");
+
+  if (!record) {
+    recordPanel.hidden = true;
+    return;
+  }
+
+  document.getElementById("record-designation").textContent = record.designation;
+  document.getElementById("record-access").textContent = `ACCESS: ${record.accessLevel}`;
+  recordGrid.innerHTML = "";
+  recordMeta.innerHTML = "";
+  driftList.innerHTML = "";
+  flagsList.innerHTML = "";
+  exposureList.innerHTML = "";
+  relatedList.innerHTML = "";
+  historyList.innerHTML = "";
+
+  [
+    ["ASSIGNMENT GROUP", record.assignmentGroup],
+    ["HANDLER SIGNAL", record.handlerSignal],
+    ["ARCHIVE AUTHORITY", record.archiveAuthority],
+    ["INTAKE NODE", record.intakeNode],
+    ["PRIMARY FREQUENCY", record.primaryFrequency],
+    ["STABILITY STATE", record.stabilityState],
+    ["ATTENTION STATUS", record.attentionStatus],
+    ["FILES REVIEWED", String(record.filesReviewed)],
+    ["INCIDENT REFERENCES", String(record.incidentExposure.length)],
+    ["KNOWN INCIDENT", record.knownIncidents.join(" // ")]
+  ].forEach(([label, value]) => addRecordField(recordGrid, label, value));
+
+  [
+    ["RECOMMENDED TRAINING", record.recommendedTraining],
+    ["VISITS", String(record.visits)],
+    ["LAST ACTIVITY", daysSince(record.lastActivity || record.lastSeen)],
+    ["LAST SEEN", formatDate(record.lastSeen)]
+  ].forEach(([label, value]) => addRecordField(recordMeta, label, value));
+
+  formatDrift(record).forEach((line) => addCompactLine(driftList, line));
+  record.observedTraits.forEach((trait) => addCompactLine(driftList, `TRAIT: ${trait}`));
+  record.archiveFlags.forEach((flag) => addCompactLine(flagsList, `✓ ${flag}`));
+  record.incidentExposure.forEach((incident) => addCompactLine(exposureList, incident));
+  record.relatedRecords.forEach((related) => addCompactLine(relatedList, related));
+
+  record.classificationHistory.forEach((entry) => {
+    addCompactLine(historyList, `[${formatDate(entry.time)}] ${entry.event}`);
+  });
+
+  recordPanel.hidden = false;
+}
+
+function addRecordField(parent, label, value) {
+  const item = document.createElement("div");
+  const term = document.createElement("span");
+  const detail = document.createElement("strong");
+
+  term.textContent = label;
+  detail.textContent = value;
+  item.append(term, detail);
+  parent.appendChild(item);
+}
+
+function addCompactLine(parent, text) {
+  const line = document.createElement("p");
+  const marker = document.createElement("span");
+  const copy = document.createElement("span");
+
+  marker.className = "prompt";
+  marker.textContent = "> ";
+  copy.textContent = text;
+  line.append(marker, copy);
+  parent.appendChild(line);
+}
+
+function renderReturningOperator(record) {
+  const returningPanel = document.getElementById("returning-operator");
+
+  if (!record || intakeState.returningDecisionMade) {
+    returningPanel.hidden = true;
+    return;
+  }
+
+  document.getElementById("returning-designation").textContent = record.designation;
+  document.getElementById("returning-frequency").textContent = record.primaryFrequency;
+  document.getElementById("returning-attention").textContent = record.attentionStatus;
+  document.getElementById("returning-access").textContent = record.accessLevel;
+  document.getElementById("returning-files").textContent = String(record.filesReviewed);
+  document.getElementById("returning-incidents").textContent = String(record.incidentExposure.length);
+  document.getElementById("returning-last-activity").textContent = daysSince(record.lastActivity || record.lastSeen);
+  returningPanel.hidden = false;
 }
 
 function writeAiLine(text, showCursor = false) {
@@ -141,6 +694,13 @@ function typeShadeIntro() {
   document.getElementById("observer-state").textContent = "NOTICED";
   document.getElementById("answer-panel").innerHTML = "";
   document.getElementById("intake-result").innerHTML = "";
+  renderOperatorRecord(intakeState.record);
+  renderReturningOperator(intakeState.record);
+
+  if (intakeState.record && !intakeState.returningDecisionMade) {
+    typeAiLine("RETURNING OPERATOR DETECTED", "Local record found. This browser remembers your intake state. No external account detected.");
+    return;
+  }
 
   typeAiLine("SHADE.DAEMON // HANDSHAKE", shadeIntro, () => {
     renderContinueButton();
@@ -185,6 +745,18 @@ function renderQuestion() {
   typeAiLine(question.step, question.prompt, () => renderAnswerChoices(question));
 }
 
+function markRecordSeen(record) {
+  if (!record) {
+    return null;
+  }
+
+  record.visits += 1;
+  record.lastSeen = nowStamp();
+  appendHistory(record, "RETURNING OPERATOR DETECTED");
+  writeOperatorRecord(record);
+  return record;
+}
+
 function openIntake() {
   const intake = document.getElementById("intake-node");
   const startButton = document.getElementById("start-intake");
@@ -192,6 +764,8 @@ function openIntake() {
   intake.hidden = false;
   startButton.setAttribute("aria-expanded", "true");
   startButton.textContent = "Intake Open";
+  intakeState.returningDecisionMade = false;
+  intakeState.record = markRecordSeen(readOperatorRecord());
   typeShadeIntro();
   intake.focus({ preventScroll: true });
   keepIntakeVisible(intake);
@@ -257,37 +831,49 @@ function selectAnswer(event) {
 function showIntakeResult() {
   const answerPanel = document.getElementById("answer-panel");
   const observerState = document.getElementById("observer-state");
-  const noticed = intakeState.answers.noticed;
-  const action = intakeState.answers.action;
-  const noticedBack = intakeState.answers.noticedBack;
-  const profile = profiles[noticed.value];
-  const risk = noticedBack.value;
+  const result = buildIntakeResult();
+  const existingRecord = intakeState.record || readOperatorRecord();
+  const record = existingRecord ? updateOperatorRecord(existingRecord, result) : createOperatorRecord(result);
 
-  observerState.textContent = risk;
+  intakeState.record = record;
+  writeOperatorRecord(record);
+  renderReturningOperator(null);
+  renderOperatorRecord(record);
+  observerState.textContent = result.risk;
   answerPanel.innerHTML = "";
 
-  typeAiLine("OUTPUT // ROUTE GENERATED", "Intake complete. Pattern match follows.", () => {
-    const claimed = risk === "CLAIMED";
+  typeAiLine("OPERATOR FILE OPENED", "Local record initialized. Observation path updated. Archive cross-reference pending.", () => {
     const lines = [
-      { text: `OBSERVER STATE: ${stateCopy[risk]}` },
-      { text: `LIKELY FREQUENCY BLEED: ${profile.title}` },
-      { text: `SUMMARY: ${profile.summary}` },
-      { text: `RESPONSE NOTE: ${actionCosts[action.value]}` },
-      { text: `RECOMMENDED ROUTE: ${profile.route}` },
-      { text: `WARNING: ${noticed.warning}`, className: "risk" },
+      { text: `DESIGNATION: ${record.designation}` },
+      { text: `ASSIGNMENT GROUP: ${record.assignmentGroup}` },
+      { text: `HANDLER SIGNAL: ${record.handlerSignal}` },
+      { text: `ARCHIVE AUTHORITY: ${record.archiveAuthority}` },
+      { text: `INTAKE NODE: ${record.intakeNode}` },
+      { text: `PRIMARY FREQUENCY: ${record.primaryFrequency}` },
+      { text: `STABILITY STATE: ${record.stabilityState}` },
+      { text: `ATTENTION STATUS: ${record.attentionStatus}` },
+      { text: `ACCESS LEVEL: ${record.accessLevel}` },
+      { text: `OBSERVED TRAITS: ${record.observedTraits.join(" // ")}` },
+      { text: `FREQUENCY DRIFT: ${formatDrift(record).join(" // ")}` },
+      { text: `KNOWN INCIDENT CROSS-REFERENCE: ${record.knownIncidents[0]}` },
+      { text: `ARCHIVE FLAGS: ${record.archiveFlags.slice(0, 3).join(" // ")}` },
+      { text: `RELATED RECORDS AVAILABLE: ${record.relatedRecords.slice(0, 3).join(" // ")}` },
+      { text: `RECOMMENDED TRAINING: ${record.recommendedTraining}` },
+      { text: "NEXT ROUTE: Continue to Archive" },
+      { text: `WARNING: ${result.warning}`, className: "risk" },
       {
-        text: claimed
-          ? "INTAKE STATUS: CLAIMED // infection report required. delay increases case-file conversion probability"
-          : "INTAKE STATUS: PASS // operator channel available",
-        className: claimed ? "risk" : "pass"
+        text: result.claimed
+          ? "INTAKE STATUS: TRIAGE // The Redacted intake will resume after stabilization"
+          : "INTAKE STATUS: PASS // The Redacted operator channel available",
+        className: result.claimed ? "risk" : "pass"
       }
     ];
 
-    typeResultLines(lines, claimed);
+    typeResultLines(lines, result.claimed, record);
   });
 }
 
-function typeResultLines(lines, claimed) {
+function typeResultLines(lines, claimed, record) {
   clearTypingTimer();
   intakeState.isTyping = true;
   const result = document.getElementById("intake-result");
@@ -311,6 +897,30 @@ function typeResultLines(lines, claimed) {
     paragraph.append(prompt, text);
     result.appendChild(paragraph);
     return text;
+  }
+
+  function appendRouteButtons() {
+    const routeWrap = document.createElement("div");
+    const archiveRoute = document.createElement("a");
+    const operatorRoute = document.createElement("a");
+
+    routeWrap.className = "route-actions";
+    archiveRoute.className = "button primary discord-route";
+    archiveRoute.href = record.archiveRoute;
+    archiveRoute.target = "_blank";
+    archiveRoute.rel = "noopener noreferrer";
+    archiveRoute.textContent = "Continue to Archive";
+    archiveRoute.addEventListener("click", () => recordArchiveInteraction("archive"));
+
+    operatorRoute.className = `button ${claimed ? "ghost" : "primary"} discord-route`;
+    operatorRoute.href = record.discordRoute;
+    operatorRoute.target = "_blank";
+    operatorRoute.rel = "noopener noreferrer";
+    operatorRoute.textContent = claimed ? "Open Triage Channel" : "Open Operator Channel";
+    operatorRoute.addEventListener("click", () => recordArchiveInteraction(claimed ? "triageChannel" : "operatorChannel"));
+
+    routeWrap.append(archiveRoute, operatorRoute);
+    result.appendChild(routeWrap);
   }
 
   function typeNextResultCharacter() {
@@ -337,21 +947,105 @@ function typeResultLines(lines, claimed) {
 
     intakeState.isTyping = false;
     typingTimer = null;
-
-    const route = document.createElement("a");
-    route.className = `button ${claimed ? "ghost" : "primary"} discord-route`;
-    route.href = claimed ? "https://discord.gg/KRbckpfTQk" : "https://discord.gg/Bn6attnYN6";
-    route.target = "_blank";
-    route.rel = "noopener noreferrer";
-    route.textContent = claimed ? "Report Infection" : "Open Operator Channel";
-    result.appendChild(route);
+    appendRouteButtons();
   }
 
   typeNextResultCharacter();
 }
 
+function resumeRecord() {
+  const record = intakeState.record || readOperatorRecord();
+
+  if (!record) {
+    return;
+  }
+
+  appendHistory(record, "LOCAL RECORD RESUMED");
+  record.lastSeen = nowStamp();
+  writeOperatorRecord(record);
+  intakeState.record = record;
+  intakeState.returningDecisionMade = true;
+  renderReturningOperator(null);
+  renderOperatorRecord(record);
+  typeAiLine("LOCAL RECORD FOUND", "Observation path restored. Return later to resume classification.");
+}
+
+function reclassifyRecord() {
+  const record = intakeState.record || readOperatorRecord();
+
+  if (record) {
+    appendHistory(record, "RECLASSIFICATION REQUESTED");
+    record.lastSeen = nowStamp();
+    writeOperatorRecord(record);
+    intakeState.record = record;
+  }
+
+  intakeState.returningDecisionMade = true;
+  renderReturningOperator(null);
+  document.getElementById("intake-result").innerHTML = "";
+  renderQuestion();
+}
+
+function purgeRecord() {
+  const record = intakeState.record || readOperatorRecord();
+
+  if (record) {
+    appendHistory(record, "LOCAL RECORD PURGED");
+  }
+
+  clearTypingTimer();
+  removeOperatorRecord();
+  intakeState.record = null;
+  intakeState.returningDecisionMade = true;
+  document.getElementById("intake-result").innerHTML = "";
+  renderReturningOperator(null);
+  renderOperatorRecord(null);
+  typeAiLine("LOCAL RECORD // PURGED", "This only removes the local browser record. No external account detected. VeilDaemon will rebuild from the next observable pattern.", () => {
+    renderContinueButton();
+  });
+}
+
 function resetIntake() {
+  intakeState.returningDecisionMade = true;
   typeShadeIntro();
+}
+
+function updateAttentionFromActivity(record) {
+  if (record.attentionStatus === "DO NOT SUSTAIN EYE CONTACT" || record.attentionStatus === "MARKED") {
+    return;
+  }
+
+  if (record.filesReviewed >= 7 || record.incidentExposure.length >= 5) {
+    record.attentionStatus = "MARKED";
+    appendHistory(record, "ATTENTION STATUS UPDATED: MARKED");
+    return;
+  }
+
+  if (record.filesReviewed >= 3 || record.incidentExposure.length >= 3) {
+    record.attentionStatus = "NOTED";
+    appendHistory(record, "ATTENTION STATUS UPDATED: NOTED");
+  }
+}
+
+function recordArchiveInteraction(type) {
+  const record = intakeState.record || readOperatorRecord();
+  const interaction = archiveInteractionProfiles[type];
+
+  if (!record || !interaction) {
+    return;
+  }
+
+  record.filesReviewed += 1;
+  record.lastActivity = nowStamp();
+  addUnique(record.archiveFlags, interaction.flag);
+  addUnique(record.incidentExposure, interaction.incident);
+  addManyUnique(record.relatedRecords, interaction.related);
+  updateAttentionFromActivity(record);
+  appendHistory(record, interaction.event);
+  appendHistory(record, "ARCHIVE CROSS-REFERENCE DETECTED");
+  writeOperatorRecord(record);
+  intakeState.record = record;
+  renderOperatorRecord(record);
 }
 
 function toggleTransmissionViewer() {
@@ -362,9 +1056,21 @@ function toggleTransmissionViewer() {
   video.hidden = isOpen;
   toggle.setAttribute("aria-expanded", String(!isOpen));
   toggle.textContent = isOpen ? "Open Transmission Viewer" : "Collapse Transmission Viewer";
+
+  if (isOpen === false) {
+    recordArchiveInteraction("transmission");
+  }
 }
 
+intakeState.record = readOperatorRecord();
+renderOperatorRecord(intakeState.record);
 document.getElementById("start-intake").addEventListener("click", openIntake);
 document.getElementById("answer-panel").addEventListener("click", selectAnswer);
 document.getElementById("reset-intake").addEventListener("click", resetIntake);
+document.getElementById("purge-record").addEventListener("click", purgeRecord);
+document.getElementById("resume-record").addEventListener("click", resumeRecord);
+document.getElementById("reclassify-record").addEventListener("click", reclassifyRecord);
+document.getElementById("returning-purge-record").addEventListener("click", purgeRecord);
 document.getElementById("open-transmission").addEventListener("click", toggleTransmissionViewer);
+document.getElementById("archive-route").addEventListener("click", () => recordArchiveInteraction("archive"));
+document.getElementById("case-file-route").addEventListener("click", () => recordArchiveInteraction("caseFile"));

--- a/styles.css
+++ b/styles.css
@@ -392,7 +392,7 @@ footer {
 }
 .intake-actions {
   display: grid;
-  grid-template-columns: minmax(11rem, .38fr);
+  grid-template-columns: repeat(2, minmax(0, 14rem));
   gap: .7rem;
   margin-top: .95rem;
 }
@@ -430,4 +430,130 @@ footer {
   .button:focus-visible::after {
     animation: none;
   }
+}
+.operator-record {
+  margin-top: .25rem;
+  padding: 1rem 1.1rem;
+  border: 1px solid rgba(102,255,220,.28);
+  background: linear-gradient(135deg, rgba(2,10,12,.62), rgba(26,4,37,.32));
+  box-shadow: inset 0 0 28px rgba(102,255,220,.06), 0 0 24px rgba(185,84,255,.08);
+}
+.operator-record[hidden] {
+  display: none;
+}
+.record-header {
+  display: flex;
+  justify-content: space-between;
+  gap: .85rem;
+  align-items: start;
+  margin-bottom: .95rem;
+}
+.record-header h3 {
+  margin: 0;
+  color: var(--text);
+  font-size: clamp(1rem, 2.6vw, 1.45rem);
+  letter-spacing: .1em;
+}
+.record-badge {
+  margin: 0;
+  padding: .4rem .55rem;
+  color: #03100d;
+  background: linear-gradient(90deg, var(--cyan), #e9fff8);
+  border: 1px solid rgba(255,255,255,.52);
+  font-size: .68rem;
+  font-weight: 800;
+  letter-spacing: .1em;
+  white-space: nowrap;
+}
+.record-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: .65rem;
+}
+.record-grid div {
+  border: 1px solid rgba(138,255,219,.2);
+  background: rgba(0,0,0,.28);
+  padding: .7rem .75rem;
+}
+.record-grid span {
+  display: block;
+  color: var(--muted);
+  font-size: .66rem;
+  letter-spacing: .13em;
+}
+.record-grid strong {
+  display: block;
+  margin-top: .32rem;
+  color: var(--text);
+  font-size: .86rem;
+  line-height: 1.35;
+}
+.record-log {
+  margin-top: .85rem;
+  padding-top: .75rem;
+  border-top: 1px solid rgba(185,84,255,.28);
+}
+.record-log p {
+  margin: .35rem 0;
+  color: #d7fff4;
+  font-size: .86rem;
+}
+@media (max-width: 760px) {
+  .record-header { display: grid; }
+  .record-badge { width: max-content; }
+  .record-grid { grid-template-columns: 1fr; }
+}
+.returning-operator {
+  padding: 1rem 1.1rem;
+  border: 1px solid rgba(185,84,255,.35);
+  background: linear-gradient(135deg, rgba(0,0,0,.48), rgba(26,4,37,.38));
+  box-shadow: inset 0 0 24px rgba(185,84,255,.08);
+}
+.returning-operator[hidden] {
+  display: none;
+}
+.returning-actions,
+.route-actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: .7rem;
+  margin-top: .9rem;
+}
+.returning-actions {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+.local-note {
+  margin: .8rem 0 0;
+  color: var(--muted);
+  font-size: .84rem;
+  line-height: 1.45;
+}
+.compact-record-grid {
+  grid-template-columns: repeat(4, 1fr);
+}
+.record-details {
+  margin-top: .75rem;
+  border-top: 1px solid rgba(185,84,255,.24);
+  padding-top: .7rem;
+}
+.record-details summary {
+  color: var(--cyan);
+  cursor: pointer;
+  font-size: .74rem;
+  font-weight: 800;
+  letter-spacing: .13em;
+  text-transform: uppercase;
+}
+.record-details summary:hover,
+.record-details summary:focus-visible {
+  color: #e9fff8;
+}
+.route-actions .discord-route {
+  width: 100%;
+  margin-top: 0;
+}
+@media (max-width: 900px) {
+  .returning-actions,
+  .route-actions,
+  .compact-record-grid { grid-template-columns: 1fr; }
 }


### PR DESCRIPTION
### Motivation
- Provide a persistent local operator record so returning users are detected and can resume or purge their intake state. 
- Surface richer intake results and local record metadata to improve routing decisions and archive interactions. 
- Track interactions with archive routes and transmissions to adjust attention state and flags over time. 

### Description
- Added UI elements and IDs in `index.html` for a returning-operator panel, an operator-record panel, new action buttons, and bumped asset query strings for `styles.css` and `script.js`.
- Implemented full local-record handling in `script.js` including `readOperatorRecord`, `writeOperatorRecord`, `removeOperatorRecord`, normalization (`normalizeOperatorRecord`), creation (`createOperatorRecord`), update (`updateOperatorRecord`), and utilities like `nowStamp`, `daysSince`, `appendHistory`, and `generateDesignation`.
- Extended intake flow to detect, render, resume, reclassify, and purge local records, and to record archive interactions via `recordArchiveInteraction`; added attention/risk logic and mapping (`attentionCopy`, `actionDrift`, `archiveInteractionProfiles`) and updated result rendering to include route buttons that log interactions.
- Introduced styles in `styles.css` for `.operator-record`, `.returning-operator`, `.record-grid`, `.record-log`, and route/returning action layouts and adjusted intake layout grid sizing.

### Testing
- No automated tests were executed for this change in CI.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a231be48d3c8333ad348762a8af53f9)